### PR TITLE
chore: add CI workflow (lint + smoke test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies (skip postinstall — needs CUDA/whisper.cpp)
+        run: npm ci --ignore-scripts
+      - name: Run ESLint
+        run: npm run lint:check
+
+  test:
+    name: Smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies (skip postinstall)
+        run: npm ci --ignore-scripts
+      - name: Run smoke test
+        run: npm test


### PR DESCRIPTION
## What does this PR do?

Adds a minimal GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on every push to `main` and every pull request targeting `main`.

## Jobs

- **Lint**: `npm run lint:check` (eslint)
- **Smoke test**: `npm test` (`scripts/smoke-test.js`)

Both jobs use `npm ci --ignore-scripts` to skip `postinstall.js` (which downloads whisper.cpp binaries / CUDA — not needed for lint or smoke test, and would slow CI to minutes).

## Why

Branch protection ruleset `protect-main` is now active. CI gives PRs (especially external ones like #20) an automated quality gate before review.

## Type of change

- [x] **Chore** / Tooling (no functional changes)

## Checklist

- [x] Workflow YAML is valid
- [x] No secrets / API keys committed
- [x] Scoped to `lint` + smoke test only (no full e2e — `test:e2e` requires bundled binaries)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated continuous integration workflow to run code linting and tests on pushes and pull requests to the main branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blue-B/WhisperSubTranslate/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->