### PR TITLE
v2.0.1: premature "Complete!" fix + tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+# Triggered by pushing a version tag, e.g.:
+#   git tag v2.0.1 && git push origin v2.0.1
+# Builds the Windows portable app natively (no wine), zips it, and publishes
+# a GitHub Release with notes from release-notes/<tag>.md or CHANGELOG.md.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write # required to create the release
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      # postinstall.js downloads the prebuilt whisper.cpp (whisper-cli.exe).
+      # GITHUB_TOKEN raises the GitHub API rate limit used during that fetch.
+      - name: Install dependencies
+        run: npm ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # electron-builder config copies ./ffprobe.exe as an extraResource, but
+      # the binary is gitignored. Stage it from the ffprobe-static package.
+      - name: Stage ffprobe.exe at repo root
+        shell: pwsh
+        run: |
+          $src = "node_modules/ffprobe-static/bin/win32/x64/ffprobe.exe"
+          if (-not (Test-Path $src)) { throw "ffprobe-static binary missing: $src" }
+          Copy-Item $src "ffprobe.exe" -Force
+          Write-Host "Staged ffprobe.exe ($((Get-Item ffprobe.exe).Length) bytes)"
+
+      - name: Sanity-check whisper-cpp download
+        shell: pwsh
+        run: |
+          $cands = @("whisper-cpp/whisper-cli.exe", "whisper-cpp/cpu/whisper-cli.exe")
+          if ($cands | Where-Object { Test-Path $_ }) {
+            Write-Host "whisper-cli.exe present"
+          } else {
+            Write-Warning "whisper-cli.exe not found - listing whisper-cpp/ for debugging:"
+            Get-ChildItem -Recurse whisper-cpp -ErrorAction SilentlyContinue | Select-Object FullName
+          }
+
+      - name: Lint + smoke test
+        run: npm run check
+
+      - name: Build Windows app (electron-builder, dir target)
+        run: npm run build-win
+
+      - name: Package portable zip
+        shell: pwsh
+        run: |
+          $zip = "dist2/WhisperSubTranslate-${{ github.ref_name }}-win-x64.zip"
+          if (-not (Test-Path "dist2/win-unpacked")) { throw "dist2/win-unpacked not found - build failed?" }
+          Compress-Archive -Path "dist2/win-unpacked/*" -DestinationPath $zip -Force
+          Write-Host "Created $zip ($((Get-Item $zip).Length) bytes)"
+
+      - name: Build release notes
+        run: node scripts/release-notes.js ${{ github.ref_name }}
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: WhisperSubTranslate ${{ github.ref_name }}
+          body_path: RELEASE_BODY.md
+          files: dist2/WhisperSubTranslate-${{ github.ref_name }}-win-x64.zip
+          draft: false
+          prerelease: false
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to WhisperSubTranslate are documented here. This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.0.1] — 2026-05-25
+
+### Fixed
+
+- **Premature "Complete!" title during translation** — the progress title flipped to "Complete!" while the job was still translating. The final batch reported `progress: 100` on the `translating` stage, pushing the overall bar to 100% before subtitle assembly and file writing finished. Translation-stage progress is now capped at 99%; 100% is only reached on the genuine `completed` stage. Most visible in high-quality (context-aware) mode, where post-translation processing takes longer.
+- **Stale "Translating…" text at 100%** — on the completed stage the progress text now reads "Translation completed!" instead of leaving the stale "Translating…" label next to a 100% bar.
+
 ## [2.0.0] — 2026-05-21
 
 Major release: context-aware translation, local HY-MT translation engine, durable file-based history, safer downloads, polished UI, and a cleaner contributor-friendly codebase.
@@ -10,7 +17,7 @@ Major release: context-aware translation, local HY-MT translation engine, durabl
 
 - **Local HY-MT translation engine** — fully offline translation via `node-llama-cpp` (HY-MT 1.5 1.8B Q4, ~1.13 GB; HY-MT 7B optional). GPU/CPU selectable.
 - **Job history (up to 200 entries)** — stored in `%APPDATA%\whispersubtranslate\history.json` (file-based, portable across builds/origins). Each row has **Open** (play result file) and **Folder** (reveal in Explorer) actions.
-- **History toggle** — Settings → History to switch logging on/off. Turning it off only stops *new* entries; existing data is preserved.
+- **History toggle** — Settings → History to switch logging on/off. Turning it off only stops _new_ entries; existing data is preserved.
 - **Forensic-safe Clear All** — overwrites the history file with zeros, deletes it, and pads out any legacy `localStorage` residue to encourage compaction. (SSD wear-leveling means software cannot guarantee 100% unrecoverability — use full-disk encryption for hard guarantees.)
 - **Cancel button while downloading a model** — both Whisper GGML and local HY-MT.
 - **Safe download interruption** — closing the window mid-download aborts the transfer; `before-quit` cancels active downloads.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whispersubtranslate",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "main.js",
   "scripts": {
     "start": "electron --expose-gc .",

--- a/renderer.js
+++ b/renderer.js
@@ -2472,7 +2472,11 @@ if (window?.electronAPI) {
       if (typeof data?.progress === 'number') {
         // 번역은 전체 작업의 50-100% 구간 (추출이 0-50%)
         const translationPct = Math.max(0, Math.min(100, data.progress));
-        const overallPct = 50 + (translationPct / 100) * 50; // 50-100 범위로 매핑
+        let overallPct = 50 + (translationPct / 100) * 50; // 50-100 범위로 매핑
+        // 'translating' 단계에서는 100%(="완료!")에 도달하지 않도록 99%로 상한 제한.
+        // 마지막 배치가 current===total로 progress=100을 보내더라도, SRT 조립·파일 저장 등
+        // 후처리가 아직 남아 있으므로 진짜 완료(=completed 단계)에서만 100%로 마무리한다.
+        if (data?.stage !== 'completed') overallPct = Math.min(overallPct, 99);
         setProgressTarget(Math.max(lastProgress, overallPct), I18N[currentUiLang].progressTranslating);
       }
       if (data?.stage === 'completed' || data?.stage === 'error') {
@@ -2487,10 +2491,12 @@ if (window?.electronAPI) {
         stopIndeterminate();
         translationSessionActive = false;
         const stageProgressTarget = isErrorStage ? 95 : 100;
-        setProgressTarget(
-          Math.max(lastProgress, stageProgressTarget),
-          data?.message || I18N[currentUiLang].progressTranslating
-        );
+        // 100%에 도달하는 완료 단계에서는 텍스트도 "완료" 계열로 맞춰 타이틀(완료!)과 일치시킨다.
+        // (이전에는 progressTranslating="번역 중..."이 남아 100%인데도 "번역 중"이 표시됐음)
+        const stageText = isErrorStage
+          ? data?.message || I18N[currentUiLang].progressTranslating
+          : data?.message || I18N[currentUiLang].translationCompleted || I18N[currentUiLang].progressComplete;
+        setProgressTarget(Math.max(lastProgress, stageProgressTarget), stageText);
 
         // 현재 처리 중인 파일을 completed로 마킹
         if (currentProcessingIndex >= 0 && currentProcessingIndex < fileQueue.length) {

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * release-notes.js - Build the GitHub Release body for a given version.
+ *
+ * Resolution order:
+ *   1. release-notes/v<version>.md  (hand-authored, multilingual; used verbatim)
+ *   2. CHANGELOG.md "## [<version>]" section  (English fallback, auto-wrapped)
+ *
+ * Usage:
+ *   node scripts/release-notes.js v2.0.1     # or: 2.0.1
+ *   RELEASE_VERSION=v2.0.1 node scripts/release-notes.js
+ *
+ * Writes RELEASE_BODY.md at repo root and prints the resolved source to stderr.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const raw = (process.argv[2] || process.env.RELEASE_VERSION || '').trim();
+if (!raw) {
+  console.error('Usage: node scripts/release-notes.js <version|vX.Y.Z>');
+  process.exit(1);
+}
+
+const version = raw.replace(/^v/, ''); // 2.0.1
+const vtag = `v${version}`;
+const root = path.join(__dirname, '..');
+const assetName = `WhisperSubTranslate-${vtag}-win-x64.zip`;
+
+let body;
+const notesFile = path.join(root, 'release-notes', `${vtag}.md`);
+
+if (fs.existsSync(notesFile)) {
+  body = fs.readFileSync(notesFile, 'utf8').trim();
+  console.error(`[release-notes] using hand-authored notes: release-notes/${vtag}.md`);
+} else {
+  const changelogPath = path.join(root, 'CHANGELOG.md');
+  if (!fs.existsSync(changelogPath)) {
+    console.error('[release-notes] CHANGELOG.md not found and no release-notes file present.');
+    process.exit(2);
+  }
+  const lines = fs.readFileSync(changelogPath, 'utf8').split('\n');
+  // Match e.g. "## [2.0.1] - 2026-05-25" (any dash style after the bracket).
+  const startRe = new RegExp('^##\\s*\\[' + version.replace(/\./g, '\\.') + '\\]');
+  const start = lines.findIndex((l) => startRe.test(l));
+  if (start === -1) {
+    console.error(`[release-notes] No CHANGELOG.md section for [${version}].`);
+    process.exit(3);
+  }
+  let end = lines.findIndex((l, i) => i > start && /^##\s*\[/.test(l));
+  if (end === -1) end = lines.length;
+  const section = lines
+    .slice(start + 1, end)
+    .join('\n')
+    .trim();
+
+  body = [
+    `## What's changed in ${vtag}`,
+    '',
+    section,
+    '',
+    '---',
+    '',
+    `**Download (Windows portable):** \`${assetName}\` — unzip and run \`WhisperSubTranslate.exe\`.`,
+    '',
+    `_For richer multilingual notes, add \`release-notes/${vtag}.md\` and it will be used verbatim._`,
+  ].join('\n');
+  console.error(`[release-notes] built from CHANGELOG.md section [${version}]`);
+}
+
+const out = path.join(root, 'RELEASE_BODY.md');
+fs.writeFileSync(out, body + '\n', 'utf8');
+console.error(`[release-notes] wrote ${out} (${body.length} chars)`);


### PR DESCRIPTION
## Summary

Brings `main` in sync with the v2.0.1 release and adds the release automation.

### Commits
1. **fix(v2.0.1): prevent premature "Complete!" during translation** — caps translating-stage progress at 99% so the 100% title ("Complete!") only shows on the genuine `completed` stage; also fixes the stale "Translating…" text at 100%. Most visible in high-quality (context-aware) mode.
2. **ci: add tag-triggered Windows release workflow** — pushing a `v*` tag builds the Windows portable app on a native `windows-latest` runner (no wine), zips it, and publishes a GitHub Release. Notes come from `release-notes/<tag>.md` or the matching `CHANGELOG.md` section.

### Note
The `v2.0.1` tag was already pushed and the Release workflow has **published the v2.0.1 release successfully**. This PR lands the same changes on `main` so the branch reflects what was shipped.

### Verification
- `npm run lint:check` — 0 errors (3 pre-existing warnings)
- `npm test` — smoke tests pass
- `release-notes.js` — verified it extracts the 2.0.1 section from CHANGELOG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Translation progress now caps at 99% until completion to prevent premature "Complete!" display
  * Progress message updated to "Translation completed!" to resolve stale status text

* **New Features**
  * History toggle setting added (Settings → History) to control history entry creation

* **Chores**
  * Version bumped to 2.0.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blue-B/WhisperSubTranslate/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->