### PR TITLE
chore(release): multilingual v2.0.1 notes + clean fallback hint

### DIFF
--- a/release-notes/v2.0.1.md
+++ b/release-notes/v2.0.1.md
@@ -1,0 +1,136 @@
+<!-- Language Selection Guide -->
+**Select your language**: Click the toggle (▼) below to expand your preferred language.
+**언어 선택**: 아래 토글(▼)을 클릭해 원하는 언어를 펼쳐 보세요.
+**言語選択**: 下のトグル(▼)をクリックして希望の言語を展開してください.
+**选择语言**: 点击下方折叠按钮(▼)展开您的首选语言.
+**Wybór języka**: Kliknij przełącznik (▼) poniżej, aby rozwinąć preferowany język.
+
+<details open>
+<summary>한국어 (KO)</summary>
+
+## 개요
+
+WhisperSubTranslate v2.0.1 — **패치 릴리즈**. 번역이 실제로 끝나기 전에 진행률 표시가 "완료!"로 미리 바뀌던 문제를 수정했습니다.
+
+## 다운로드
+
+- **Windows 포터블(권장)**: `WhisperSubTranslate-v2.0.1-win-x64.zip`
+  → 압축 해제 → `WhisperSubTranslate.exe` 실행
+- **Linux/macOS**: 소스에서 직접 실행 (README의 Linux Setup 참조)
+
+---
+
+## 🐛 버그 수정
+
+- **번역 중 "완료!" 조기 표시 수정** — 마지막 배치가 진행률 100%를 보고하면, 자막 조립·파일 저장 같은 후처리가 끝나기도 전에 상단 타이틀이 "완료!"로 바뀌었습니다. 이제 번역 단계 진행률은 **99%까지만** 차오르고, 진짜 완료(`completed`) 단계에서만 100%에 도달합니다. 후처리가 긴 **고품질(컨텍스트 인식) 모드**에서 특히 두드러졌습니다.
+- **100%인데 "번역 중…"으로 남던 텍스트 수정** — 완료 단계에서 진행률 텍스트가 "번역 완료!"로 정확히 표시됩니다.
+
+## 업데이트 방법
+
+- **Windows**: Releases에서 v2.0.1 다운로드 → 기존 설치 폴더에 덮어쓰기. 설정·히스토리·API 키는 그대로 유지됩니다.
+
+</details>
+
+<details>
+<summary>English (EN)</summary>
+
+## Overview
+
+WhisperSubTranslate v2.0.1 — **patch release**. Fixes the progress indicator that flipped to "Complete!" before the job had actually finished translating.
+
+## Download
+
+- **Windows Portable (Recommended)**: `WhisperSubTranslate-v2.0.1-win-x64.zip`
+  → Extract → Run `WhisperSubTranslate.exe`
+- **Linux/macOS**: Run from source (see Linux Setup in README)
+
+---
+
+## 🐛 Fixes
+
+- **Premature "Complete!" title during translation** — when the final batch reported 100% progress, the header title flipped to "Complete!" before post-processing (subtitle assembly, file write) had finished. Translation-stage progress is now capped at **99%**, and 100% is only reached at the genuine `completed` stage. Most visible in **high-quality (context-aware) mode**, where post-translation processing takes longer.
+- **Stale "Translating…" text at 100%** — the completed stage now reads "Translation completed!" instead of leaving "Translating…" next to a full bar.
+
+## How to update
+
+- **Windows**: download v2.0.1 from Releases and overwrite your existing folder. Settings, history, and API keys are preserved.
+
+</details>
+
+<details>
+<summary>日本語 (JA)</summary>
+
+## 概要
+
+WhisperSubTranslate v2.0.1 — **パッチリリース**。翻訳がまだ完了していないのに進捗表示が「完了!」に変わってしまう問題を修正しました。
+
+## ダウンロード
+
+- **Windowsポータブル(推奨)**: `WhisperSubTranslate-v2.0.1-win-x64.zip`
+  → 解凍 → `WhisperSubTranslate.exe` を実行
+- **Linux/macOS**: ソースから実行(READMEのLinux Setupを参照)
+
+---
+
+## 🐛 修正
+
+- **翻訳中に「完了!」が早く表示される問題を修正** — 最後のバッチが進捗100%を報告すると、字幕の組み立てやファイル保存などの後処理が終わる前にタイトルが「完了!」に変わっていました。翻訳段階の進捗は **99%まで** に制限され、本当の完了(`completed`)段階でのみ100%に到達します。後処理が長い **高品質(コンテキスト認識)モード** で特に目立っていました。
+- **100%なのに「翻訳中…」のままだったテキストを修正** — 完了段階では「翻訳完了!」と正しく表示されます。
+
+## アップデート方法
+
+- **Windows**: Releasesからv2.0.1をダウンロードし、既存フォルダに上書き。設定・履歴・APIキーは保持されます。
+
+</details>
+
+<details>
+<summary>中文 (ZH)</summary>
+
+## 概述
+
+WhisperSubTranslate v2.0.1 — **补丁版本**。修复翻译尚未真正完成时进度显示就提前变为"完成!"的问题。
+
+## 下载
+
+- **Windows便携版(推荐)**: `WhisperSubTranslate-v2.0.1-win-x64.zip`
+  → 解压 → 运行 `WhisperSubTranslate.exe`
+- **Linux/macOS**: 从源码运行(参见 README 中的 Linux Setup)
+
+---
+
+## 🐛 修复
+
+- **修复翻译过程中过早显示"完成!"的问题** — 当最后一批报告进度100%时，在字幕组装、文件写入等后处理完成之前，标题就变成了"完成!"。现在翻译阶段的进度**最多到99%**，只有在真正的完成(`completed`)阶段才会到达100%。在后处理较长的**高质量(上下文感知)模式**下尤为明显。
+- **修复100%时仍显示"翻译中…"的文本** — 完成阶段现在显示"翻译完成!"。
+
+## 更新方法
+
+- **Windows**: 从 Releases 下载 v2.0.1 并覆盖现有文件夹。设置、历史、API 密钥均会保留。
+
+</details>
+
+<details>
+<summary>Polski (PL)</summary>
+
+## Przegląd
+
+WhisperSubTranslate v2.0.1 — **wydanie poprawkowe**. Naprawia wskaźnik postępu, który zmieniał się na „Ukończono!" zanim zadanie faktycznie zakończyło tłumaczenie.
+
+## Pobieranie
+
+- **Windows przenośna (zalecana)**: `WhisperSubTranslate-v2.0.1-win-x64.zip`
+  → Rozpakuj → Uruchom `WhisperSubTranslate.exe`
+- **Linux/macOS**: Uruchom ze źródeł (patrz Linux Setup w README)
+
+---
+
+## 🐛 Poprawki
+
+- **Przedwczesny tytuł „Ukończono!" podczas tłumaczenia** — gdy ostatnia partia raportowała 100% postępu, tytuł zmieniał się na „Ukończono!" zanim zakończyło się przetwarzanie końcowe (składanie napisów, zapis pliku). Postęp etapu tłumaczenia jest teraz ograniczony do **99%**, a 100% osiągane jest dopiero na prawdziwym etapie `completed`. Najbardziej widoczne w **trybie wysokiej jakości (context-aware)**, gdzie przetwarzanie końcowe trwa dłużej.
+- **Nieaktualny tekst „Tłumaczenie…" przy 100%** — etap completed pokazuje teraz „Tłumaczenie ukończone!" zamiast pozostawiać „Tłumaczenie…" obok pełnego paska.
+
+## Jak zaktualizować
+
+- **Windows**: pobierz v2.0.1 z Releases i nadpisz istniejący folder. Ustawienia, historia i klucze API są zachowane.
+
+</details>

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -63,8 +63,6 @@ if (fs.existsSync(notesFile)) {
     '---',
     '',
     `**Download (Windows portable):** \`${assetName}\` — unzip and run \`WhisperSubTranslate.exe\`.`,
-    '',
-    `_For richer multilingual notes, add \`release-notes/${vtag}.md\` and it will be used verbatim._`,
   ].join('\n');
   console.error(`[release-notes] built from CHANGELOG.md section [${version}]`);
 }


### PR DESCRIPTION
## Summary

Follow-up to the v2.0.1 release: provides proper multilingual release notes and removes an internal hint that leaked into the published English fallback.

- **`release-notes/v2.0.1.md`** — full KO / EN / JA / ZH / PL notes using the same language-toggle `<details>` layout as previous releases. The release workflow (`scripts/release-notes.js`) now uses this verbatim.
- **`scripts/release-notes.js`** — removed the `_For richer multilingual notes, add release-notes/<tag>.md…_` line that was appended to the English CHANGELOG fallback and showed up in the v2.0.1 release body.

The published v2.0.1 release body has already been updated to this multilingual content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed translation progress display to show "Complete!" only after translation truly finishes (capped at 99% during active translation)
  * Fixed status message at 100% progress to display "Translation completed!" instead of "Translating…"

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blue-B/WhisperSubTranslate/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->