### PR TITLE
fix(translation): stabilize local model sessions for v2.4.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to WhisperSubTranslate are documented here. This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.4.3] - 2026-07-20
+
+Patch release for the Turkish translation target, macOS whisper runtime detection, and local Hy-MT2 reliability.
+
+### Added
+
+- **Turkish translation target** - Turkish (`tr`) is available in the target picker, provider mappings, localized labels, documentation, and UI tests.
+
+### Fixed
+
+- **Local translation hanging after a device or model change** - switching between Auto and CPU could deadlock because model loading tried to acquire a lock already held by the current translation. Model load, translation, and unload now share one serialized operation queue without nested locking.
+- **Stop and timeout handling for local translation** - stopping a job now aborts active Hy-MT2 inference, and model operations fail with a clear error after three minutes instead of waiting indefinitely.
+- **Untranslated local output detection** - comparisons now ignore case, Unicode width, spacing, and punctuation, catch short labeled echoes such as `Original: ...`, and reject files when at least 80% of cues are effectively unchanged.
+- **macOS whisper runtime detection** - the installer validates the downloaded CLI by launching it and only applies the `dyld` fallback when the runtime error actually matches a missing shared library.
+- **Korean drop-zone hint** - restored the functional file-selection text after an unrelated translation update replaced it.
+
+### Internal
+
+- Renderer status markup is built with DOM nodes, and translated HTML used by model and queue views is filtered before insertion.
+- Pull requests now verify that generated locale output matches the source JSON files.
+
 ## [2.4.2] — 2026-06-24
 
 Sync accuracy release: a dedicated Faster-Whisper engine repairs subtitle drift, the unreliable SenseVoice timing path is gone, and local translation no longer fails silently or shows misleading API errors.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ Patch release for the Turkish translation target, macOS whisper runtime detectio
 ### Fixed
 
 - **Local translation hanging after a device or model change** - switching between Auto and CPU could deadlock because model loading tried to acquire a lock already held by the current translation. Model load, translation, and unload now share one serialized operation queue without nested locking.
-- **Stop and timeout handling for local translation** - stopping a job now aborts active Hy-MT2 inference, and model operations fail with a clear error after three minutes instead of waiting indefinitely.
+- **Stop and timeout handling for local translation** - stopping a job now aborts active Hy-MT2 inference or model download, and model operations fail with a clear error after three minutes instead of waiting indefinitely.
 - **Untranslated local output detection** - comparisons now ignore case, Unicode width, spacing, and punctuation, catch short labeled echoes such as `Original: ...`, and reject files when at least 80% of cues are effectively unchanged.
 - **macOS whisper runtime detection** - the installer validates the downloaded CLI by launching it and only applies the `dyld` fallback when the runtime error actually matches a missing shared library.
 - **Korean drop-zone hint** - restored the functional file-selection text after an unrelated translation update replaced it.

--- a/local-translator.js
+++ b/local-translator.js
@@ -40,6 +40,7 @@ const MODELS = {
   },
 };
 const DEFAULT_MODEL_ID = '1.8b';
+const LOCAL_OPERATION_TIMEOUT_MS = 3 * 60 * 1000;
 
 function getModelUrl(modelId) {
   const m = MODELS[modelId];
@@ -101,12 +102,31 @@ function buildTranslationPrompt(text, targetLang) {
   return `Translate the following segment into ${targetName}, without additional explanation.\n\n${text}`;
 }
 
-// 번역 실패(echo) 감지: 비 CJK 타깃인데 출력이 여전히 CJK 위주면 원문 통과로 판정.
-// 소스에 CJK가 거의 없으면(기호·숫자·라틴 자막) 판정하지 않는다 — 오탐 방지.
+function normalizeComparableText(text) {
+  return String(text || '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[\p{P}\p{S}\s]+/gu, '');
+}
+
+function isEffectivelySameText(output, source, minLength = 8) {
+  const src = normalizeComparableText(source);
+  const out = normalizeComparableText(output);
+  if (src.length < minLength) return false;
+  if (out === src) return true;
+
+  // "Original: <source>"처럼 짧은 라벨만 붙인 echo도 번역으로 인정하지 않는다.
+  const extraLength = out.length - src.length;
+  return extraLength > 0 && extraLength <= Math.max(16, Math.ceil(src.length * 0.35)) && out.includes(src);
+}
+
+// 번역 실패(echo) 감지: 공백/문장부호만 달라진 원문 반환은 모든 언어에서 잡고,
+// CJK 원문→비 CJK 타깃은 문자 비율로 한 번 더 판정한다.
 function looksUntranslated(output, source, targetLang) {
   const out = (output || '').trim();
   if (!out) return true;
   const src = (source || '').trim();
+  if (isEffectivelySameText(out, src)) return true;
   const srcCjk = (src.match(/[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af]/g) || []).length;
   if (srcCjk < 2) return false;
   if (targetLang === 'ja' || targetLang === 'zh' || targetLang === 'zh-Hant' || targetLang === 'yue') {
@@ -129,7 +149,42 @@ let _currentModelId = null; // '1.8b' | '7b'
 let _downloadPromises = {}; // modelId → Promise
 let _loadPromise = null;
 let _translateMutex = Promise.resolve();
+let _activeAbortController = null;
 let _onDownloadProgress = null;
+
+async function withTimeout(run, timeoutMs = LOCAL_OPERATION_TIMEOUT_MS, parentSignal = null) {
+  const controller = new AbortController();
+  const abortFromParent = () => controller.abort(parentSignal.reason);
+  if (parentSignal?.aborted) abortFromParent();
+  else parentSignal?.addEventListener('abort', abortFromParent, { once: true });
+  const timer = setTimeout(() => {
+    controller.abort(new Error(`LOCAL_TIMEOUT: local model operation exceeded ${timeoutMs}ms`));
+  }, timeoutMs);
+
+  try {
+    if (controller.signal.aborted) throw controller.signal.reason;
+    return await run(controller.signal);
+  } catch (error) {
+    if (controller.signal.aborted) throw controller.signal.reason;
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    parentSignal?.removeEventListener('abort', abortFromParent);
+  }
+}
+
+function abortTranslation() {
+  if (_activeAbortController && !_activeAbortController.signal.aborted) {
+    _activeAbortController.abort(new Error('ABORTED: Translation stopped by user'));
+  }
+}
+
+async function acquireTranslateLock() {
+  return await new Promise((resolve) => {
+    const prev = _translateMutex;
+    _translateMutex = new Promise((release) => prev.then(() => resolve(release)));
+  });
+}
 
 function getModelsDir() {
   const { app } = require('electron');
@@ -328,15 +383,16 @@ function deleteModel(modelId = DEFAULT_MODEL_ID) {
  * @param {string} device - 'auto' (GPU 우선) 또는 'cpu'
  * @param {string} modelId - '1.8b' | '7b'
  */
-async function loadModel(device = 'auto', modelId = DEFAULT_MODEL_ID) {
+async function loadModelUnlocked(device = 'auto', modelId = DEFAULT_MODEL_ID, signal = null) {
   const desiredMode = device === 'cpu' ? 'cpu' : 'auto';
   if (_model && _currentGpuMode === desiredMode && _currentModelId === modelId) return;
   if (_loadPromise) return _loadPromise;
   _loadPromise = (async () => {
-    if (_model) await unloadModel();
+    // translateLocal이 잡은 mutex 안에서 다시 unloadModel의 mutex를 기다리면 교착된다.
+    if (_model || _llama) await disposeModel();
     const { getLlama } = await import('node-llama-cpp');
     _llama = await getLlama({ gpu: desiredMode === 'cpu' ? false : 'auto' });
-    _model = await _llama.loadModel({ modelPath: getModelPath(modelId) });
+    _model = await _llama.loadModel({ modelPath: getModelPath(modelId), loadSignal: signal });
     _currentGpuMode = desiredMode;
     _currentModelId = modelId;
     console.log(
@@ -348,6 +404,15 @@ async function loadModel(device = 'auto', modelId = DEFAULT_MODEL_ID) {
   return _loadPromise;
 }
 
+async function loadModel(device = 'auto', modelId = DEFAULT_MODEL_ID, signal = null) {
+  const release = await acquireTranslateLock();
+  try {
+    return await loadModelUnlocked(device, modelId, signal);
+  } finally {
+    release();
+  }
+}
+
 /**
  * Translate text using local HY-MT model.
  * @param {string} text
@@ -356,18 +421,18 @@ async function loadModel(device = 'auto', modelId = DEFAULT_MODEL_ID) {
  * @param {string} modelId - '1.8b' | '7b'
  */
 async function translateLocal(text, targetLang, device = 'auto', modelId = DEFAULT_MODEL_ID) {
-  const release = await new Promise((resolve) => {
-    const prev = _translateMutex;
-    _translateMutex = new Promise((r) => prev.then(() => resolve(r)));
-  });
+  const release = await acquireTranslateLock();
+  const controller = new AbortController();
+  _activeAbortController = controller;
   try {
-    return await _translateLocalImpl(text, targetLang, device, modelId);
+    return await _translateLocalImpl(text, targetLang, device, modelId, controller.signal);
   } finally {
+    if (_activeAbortController === controller) _activeAbortController = null;
     release();
   }
 }
 
-async function _translateLocalImpl(text, targetLang, device, modelId) {
+async function _translateLocalImpl(text, targetLang, device, modelId, signal) {
   _maybeCleanupLegacy();
   if (!isModelInstalled(modelId)) {
     console.log(`[Local] 모델 미설치 감지 (${modelId}) → 자동 다운로드 시작...`);
@@ -377,24 +442,34 @@ async function _translateLocalImpl(text, targetLang, device, modelId) {
           `[Local] 다운로드 ${p.percent}% (${Math.round(p.downloaded / 1024 / 1024)}MB / ${Math.round(p.total / 1024 / 1024)}MB)`
         );
       },
-      null,
+      signal,
       modelId
     );
   }
 
-  await loadModel(device, modelId);
-
-  if (!_context) {
-    _context = await _model.createContext({ contextSize: 2048 });
+  try {
+    await withTimeout(
+      async (operationSignal) => {
+        await loadModelUnlocked(device, modelId, operationSignal);
+        if (!_context) {
+          _context = await _model.createContext({ contextSize: 2048, createSignal: operationSignal });
+        }
+      },
+      LOCAL_OPERATION_TIMEOUT_MS,
+      signal
+    );
+    const { LlamaChatSession } = await import('node-llama-cpp');
+    if (!_session) {
+      _session = new LlamaChatSession({
+        contextSequence: _context.getSequence(),
+        chatWrapper: 'auto',
+      });
+    }
+    _session.resetChatHistory();
+  } catch (error) {
+    await disposeModel();
+    throw error;
   }
-  const { LlamaChatSession } = await import('node-llama-cpp');
-  if (!_session) {
-    _session = new LlamaChatSession({
-      contextSequence: _context.getSequence(),
-      chatWrapper: 'auto',
-    });
-  }
-  _session.resetChatHistory();
 
   const prompt = buildTranslationPrompt(text, targetLang);
   const samplingBase = {
@@ -407,13 +482,25 @@ async function _translateLocalImpl(text, targetLang, device, modelId) {
   let response;
   try {
     // 1차: 결정적 샘플링(temp 0) — 자막 번역은 무작위성이 echo(원문 그대로 출력) 사고를 키운다
-    response = (await _session.prompt(prompt, { ...samplingBase, temperature: 0 })).trim();
+    response = (
+      await withTimeout(
+        (operationSignal) => _session.prompt(prompt, { ...samplingBase, temperature: 0, signal: operationSignal }),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        signal
+      )
+    ).trim();
 
     // echo 감지 시 공식 권장 샘플링(temp 0.7)으로 1회 재시도
     if (looksUntranslated(response, text, targetLang)) {
       console.warn(`[Local] 번역 결과가 원문 그대로임 → 재시도: "${text.substring(0, 40)}"`);
       _session.resetChatHistory();
-      response = (await _session.prompt(prompt, { ...samplingBase, temperature: 0.7 })).trim();
+      response = (
+        await withTimeout(
+          (operationSignal) => _session.prompt(prompt, { ...samplingBase, temperature: 0.7, signal: operationSignal }),
+          LOCAL_OPERATION_TIMEOUT_MS,
+          signal
+        )
+      ).trim();
     }
   } catch (e) {
     try {
@@ -434,33 +521,34 @@ async function _translateLocalImpl(text, targetLang, device, modelId) {
   return response;
 }
 
-async function unloadModel() {
-  const release = await new Promise((resolve) => {
-    const prev = _translateMutex;
-    _translateMutex = new Promise((r) => prev.then(() => resolve(r)));
-  });
+async function disposeModel() {
   try {
-    try {
-      if (_context) await _context.dispose();
-    } catch {
-      /* ignore */
-    }
-    try {
-      if (_model) await _model.dispose();
-    } catch {
-      /* ignore */
-    }
-    try {
-      if (_llama) await _llama.dispose();
-    } catch {
-      /* ignore */
-    }
-    _session = null;
-    _context = null;
-    _model = null;
-    _llama = null;
-    _currentGpuMode = null;
-    _currentModelId = null;
+    if (_context) await _context.dispose();
+  } catch {
+    /* ignore */
+  }
+  try {
+    if (_model) await _model.dispose();
+  } catch {
+    /* ignore */
+  }
+  try {
+    if (_llama) await _llama.dispose();
+  } catch {
+    /* ignore */
+  }
+  _session = null;
+  _context = null;
+  _model = null;
+  _llama = null;
+  _currentGpuMode = null;
+  _currentModelId = null;
+}
+
+async function unloadModel() {
+  const release = await acquireTranslateLock();
+  try {
+    await disposeModel();
   } finally {
     release();
   }
@@ -478,7 +566,10 @@ module.exports = {
   loadModel,
   translateLocal,
   buildTranslationPrompt,
+  isEffectivelySameText,
   looksUntranslated,
+  withTimeout,
+  abortTranslation,
   unloadModel,
   setDownloadProgressHandler,
   cleanupLegacyModels,

--- a/local-translator.js
+++ b/local-translator.js
@@ -286,12 +286,22 @@ async function downloadModel(onProgress, signal, modelId = DEFAULT_MODEL_ID) {
           }
       };
     }
-    return _downloadPromises[modelId];
+    return await waitForDownload(_downloadPromises[modelId], signal);
   }
   _downloadPromises[modelId] = _downloadModelImpl(onProgress, signal, modelId).finally(() => {
     delete _downloadPromises[modelId];
   });
-  return _downloadPromises[modelId];
+  return await waitForDownload(_downloadPromises[modelId], signal);
+}
+
+function waitForDownload(promise, signal) {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(signal.reason || new Error('Download cancelled'));
+  return new Promise((resolve, reject) => {
+    const onAbort = () => reject(signal.reason || new Error('Download cancelled'));
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort));
+  });
 }
 
 async function _downloadModelImpl(onProgress, signal, modelId) {
@@ -303,36 +313,52 @@ async function _downloadModelImpl(onProgress, signal, modelId) {
   const tmp = dest + '.tmp';
 
   return new Promise((resolve, reject) => {
-    const doRequest = (url, redirects = 0) => {
-      if (redirects > 5) return reject(new Error('Too many redirects'));
+    let settled = false;
+    const abortError = () =>
+      signal?.reason instanceof Error ? signal.reason : new Error('Download cancelled');
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      try {
+        fs.unlinkSync(tmp);
+      } catch {}
+      reject(error);
+    };
 
-      const req = https.get(url, (res) => {
+    const doRequest = (url, redirects = 0) => {
+      if (settled) return;
+      if (signal?.aborted) return fail(abortError());
+      if (redirects > 5) return fail(new Error('Too many redirects'));
+
+      let out = null;
+      let req = null;
+      const detachAbort = () => signal?.removeEventListener('abort', abortRequest);
+      const abortRequest = () => {
+        req?.destroy();
+        out?.destroy();
+        fail(abortError());
+      };
+
+      req = https.get(url, (res) => {
         if (res.statusCode === 301 || res.statusCode === 302) {
+          detachAbort();
           res.resume();
           return doRequest(res.headers.location, redirects + 1);
         }
         if (res.statusCode !== 200) {
-          return reject(new Error(`HTTP ${res.statusCode}`));
+          detachAbort();
+          res.resume();
+          return fail(new Error(`HTTP ${res.statusCode}`));
         }
 
         const total = parseInt(res.headers['content-length'] || m.sizeBytes, 10);
         let downloaded = 0;
-        const out = fs.createWriteStream(tmp);
-
-        if (signal) {
-          signal.addEventListener(
-            'abort',
-            () => {
-              req.destroy();
-              out.destroy();
-              try {
-                fs.unlinkSync(tmp);
-              } catch {}
-              reject(new Error('Download cancelled'));
-            },
-            { once: true }
-          );
-        }
+        out = fs.createWriteStream(tmp);
+        out.on('error', (error) => {
+          detachAbort();
+          res.destroy();
+          fail(error);
+        });
 
         res.on('data', (chunk) => {
           downloaded += chunk.length;
@@ -351,20 +377,30 @@ async function _downloadModelImpl(onProgress, signal, modelId) {
         });
 
         res.on('end', () => {
-          out.close(() => {
-            fs.renameSync(tmp, dest);
-            resolve(dest);
+          detachAbort();
+          out.end(() => {
+            if (settled) return;
+            try {
+              fs.renameSync(tmp, dest);
+              settled = true;
+              resolve(dest);
+            } catch (error) {
+              fail(error);
+            }
           });
         });
 
-        res.on('error', (e) => {
+        res.on('error', (error) => {
+          detachAbort();
           out.destroy();
-          reject(e);
+          fail(error);
         });
       });
 
-      req.on('error', (e) => {
-        if (e.message !== 'Download cancelled') reject(e);
+      signal?.addEventListener('abort', abortRequest, { once: true });
+      req.on('error', (error) => {
+        detachAbort();
+        fail(signal?.aborted ? abortError() : error);
       });
     };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "whispersubtranslate",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "whispersubtranslate",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whispersubtranslate",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },

--- a/renderer.js
+++ b/renderer.js
@@ -30,6 +30,48 @@ let soundMuted = localStorage.getItem('soundMuted') === 'true';
 // 실패 항목 자동 재시도 상한 — 무한루프 방지 (파일당 autoRetryCount로 추적)
 const AUTO_RETRY_MAX = 2;
 
+// 번역 상태 문자열은 locales의 <strong>/<br>만 허용해 DOM으로 만든다.
+function setStatusMarkup(element, markup) {
+  const fragment = document.createDocumentFragment();
+  let parent = fragment;
+  String(markup || '')
+    .split(/(<strong(?:\s[^>]*)?>|<\/strong>|<br\s*\/?>)/gi)
+    .filter(Boolean)
+    .forEach((part) => {
+      if (/^<strong/i.test(part)) {
+        const strong = document.createElement('strong');
+        if (/color\s*:\s*#e74c3c/i.test(part)) strong.style.color = '#e74c3c';
+        fragment.appendChild(strong);
+        parent = strong;
+      } else if (/^<\/strong/i.test(part)) {
+        parent = fragment;
+      } else if (/^<br/i.test(part)) {
+        fragment.appendChild(document.createElement('br'));
+      } else {
+        parent.appendChild(document.createTextNode(part));
+      }
+    });
+  element.replaceChildren(fragment);
+}
+
+function setSafeHtml(element, markup) {
+  const doc = new DOMParser().parseFromString(String(markup || ''), 'text/html');
+  doc.querySelectorAll('script,iframe,object,embed,link,meta,style,base').forEach((node) => node.remove());
+  doc.body.querySelectorAll('*').forEach((node) => {
+    Array.from(node.attributes).forEach((attr) => {
+      const name = attr.name.toLowerCase();
+      if (
+        name.startsWith('on') ||
+        name === 'srcdoc' ||
+        (['href', 'src', 'xlink:href', 'formaction'].includes(name) && /^\s*(?:javascript|vbscript):/i.test(attr.value))
+      ) {
+        node.removeAttribute(attr.name);
+      }
+    });
+  });
+  element.replaceChildren(...Array.from(doc.body.childNodes, (node) => document.importNode(node, true)));
+}
+
 // Toast notification (토스트 알림)
 function showToast(message, options = {}) {
   // 기존 토스트 제거
@@ -175,13 +217,18 @@ function updateUIMode() {
       // 항상 내용 업데이트 (언어 변경 대응)
       // "번역 안함" 선택 시 SRT 스킵 예고 경고 추가
       const translationValue = translationSelect?.value;
+      const warning = document.createElement('span');
+      warning.textContent = warningText;
       if (translationValue === 'none') {
         const skipWarningText =
           d.srtWillBeSkipped ||
           'SRT files will be skipped without translation settings. Please select a translation method.';
-        mixedWarning.innerHTML = `<span>${warningText}</span><span class="skip-warning">${skipWarningText}</span>`;
+        const skipWarning = document.createElement('span');
+        skipWarning.className = 'skip-warning';
+        skipWarning.textContent = skipWarningText;
+        mixedWarning.replaceChildren(warning, skipWarning);
       } else {
-        mixedWarning.innerHTML = `<span>${warningText}</span>`;
+        mixedWarning.replaceChildren(warning);
       }
     } else {
       const mixedWarning = document.getElementById('mixedFileWarning');
@@ -1239,9 +1286,7 @@ async function continueProcessing() {
     // 실패 항목 자동 재시도(옵션): 큐가 끝난 시점에 error 항목을 상한 회수까지 다시 태운다.
     // 사용자가 직접 중지한 경우(shouldStop/stopped)는 건드리지 않는다.
     if (!shouldStop && localStorage.getItem('autoRetryFailed') === 'true') {
-      const retryables = fileQueue.filter(
-        (f) => f.status === 'error' && (f.autoRetryCount || 0) < AUTO_RETRY_MAX
-      );
+      const retryables = fileQueue.filter((f) => f.status === 'error' && (f.autoRetryCount || 0) < AUTO_RETRY_MAX);
       if (retryables.length > 0) {
         retryables.forEach((f) => {
           f.autoRetryCount = (f.autoRetryCount || 0) + 1;
@@ -1698,7 +1743,7 @@ function getLocalizedError(errorMessage) {
   if (errorMessage.includes('SRT file path missing') || errorMessage.includes('SRT 파일 경로')) {
     return lang.errorSrtPathMissing;
   }
-  if (errorMessage.includes('TRANSLATION_PASSTHROUGH')) {
+  if (errorMessage.includes('TRANSLATION_PASSTHROUGH') || errorMessage.includes('LOCAL_TIMEOUT')) {
     return lang.errorTranslationPassthrough || lang.errorEmptyTranslation;
   }
   if (errorMessage.includes('empty translation') || errorMessage.includes('번역 결과가 비어')) {
@@ -1775,7 +1820,8 @@ const MODEL_I18N = {
 const MODEL_DESC_I18N = {
   ko: {
     'large-v3-turbo': '빠르고 싱크 정확, 대부분 영상에 적합',
-    'large-v2-sync': '싱크가 안 맞는 영상 교정용. 비영어(일/한/중)에 가장 정확, 영어는 turbo로 충분. 장치 선택 따름. 느림',
+    'large-v2-sync':
+      '싱크가 안 맞는 영상 교정용. 비영어(일/한/중)에 가장 정확, 영어는 turbo로 충분. 장치 선택 따름. 느림',
     'large-v2-sync-lite': '정밀과 같은 모델을 int8로 가볍게. VRAM 약 3GB, 렉 적음. 싱크 품질은 거의 동일',
     'large-v3': '받아쓰기는 조금 더 정확하지만 긴 영상에서 싱크가 밀리고 느림',
     medium: '고사양 PC용, GPU 없어도 됨',
@@ -1785,7 +1831,8 @@ const MODEL_DESC_I18N = {
   },
   en: {
     'large-v3-turbo': 'Fast, accurate sync, best for most videos',
-    'large-v2-sync': 'Fixes subtitles that will not sync. Best for non-English (JA/KO/ZH); English is fine with turbo. Follows device choice. Slow',
+    'large-v2-sync':
+      'Fixes subtitles that will not sync. Best for non-English (JA/KO/ZH); English is fine with turbo. Follows device choice. Slow',
     'large-v2-sync-lite': 'Same model in int8, lighter. ~3GB VRAM, less lag. Sync quality nearly identical',
     'large-v3': 'Slightly better text but sync drifts and slower on long videos',
     medium: 'High-spec PC, works without GPU',
@@ -1795,7 +1842,8 @@ const MODEL_DESC_I18N = {
   },
   ja: {
     'large-v3-turbo': '高速で同期正確、ほとんどの動画に最適',
-    'large-v2-sync': '同期が合わない映像の補正用。非英語(日/韓/中)に最も正確、英語はturboで十分。デバイス選択に従う。低速',
+    'large-v2-sync':
+      '同期が合わない映像の補正用。非英語(日/韓/中)に最も正確、英語はturboで十分。デバイス選択に従う。低速',
     'large-v2-sync-lite': '精密と同じモデルをint8で軽量化。VRAM約3GB、ラグ少。同期品質はほぼ同じ',
     'large-v3': '文字起こしはやや上だが長い動画で同期がずれ、低速',
     medium: '高スペックPC用、GPU不要',
@@ -1815,7 +1863,8 @@ const MODEL_DESC_I18N = {
   },
   pl: {
     'large-v3-turbo': 'Szybki, dokładna synchronizacja, najlepszy do większości filmów',
-    'large-v2-sync': 'Naprawia napisy bez synchronizacji. Najlepszy dla nieangielskich (JA/KO/ZH); angielski OK z turbo. Wg wyboru urządzenia. Wolny',
+    'large-v2-sync':
+      'Naprawia napisy bez synchronizacji. Najlepszy dla nieangielskich (JA/KO/ZH); angielski OK z turbo. Wg wyboru urządzenia. Wolny',
     'large-v2-sync-lite': 'Ten sam model w int8, lżejszy. ~3GB VRAM, mniej zacięć. Synchronizacja prawie identyczna',
     'large-v3': 'Lepszy tekst, ale synchronizacja dryfuje i wolniejszy w długich filmach',
     medium: 'Wydajny PC, bez GPU',
@@ -1936,7 +1985,7 @@ function rebuildLanguageSelectOptions(lang) {
   if (!sel) return;
   const originalValue = sel.value;
   const codes = ['auto', 'ko', 'en', 'ja', 'zh', 'es', 'fr', 'de', 'it', 'pt', 'ru', 'hu', 'ar', 'pl'];
-  sel.innerHTML = '';
+  sel.replaceChildren();
   codes.forEach((code) => {
     const opt = document.createElement('option');
     opt.value = code;
@@ -1958,7 +2007,7 @@ function rebuildDeviceSelectOptions(lang) {
   });
   sel.value = original;
   const deviceStatus = document.getElementById('deviceStatus');
-  if (deviceStatus) deviceStatus.innerHTML = I18N[lang].deviceStatusHtml;
+  if (deviceStatus) setStatusMarkup(deviceStatus, I18N[lang].deviceStatusHtml);
 }
 
 function rebuildTranslationSelectOptions(lang) {
@@ -1973,15 +2022,18 @@ function rebuildTranslationSelectOptions(lang) {
   sel.value = original;
   const translationStatus = document.getElementById('translationStatus');
   if (translationStatus) {
-    if (original === 'none') translationStatus.innerHTML = I18N[lang].translationDisabledHtml;
-    else if (original === 'local') updateLocalModelStatus();
-    else if (original === 'deepl')
-      translationStatus.innerHTML = I18N[lang].translationDeeplHtml || I18N[lang].translationEnabledHtml;
+    let statusMarkup = I18N[lang].translationEnabledHtml;
+    if (original === 'none') statusMarkup = I18N[lang].translationDisabledHtml;
+    else if (original === 'local') {
+      updateLocalModelStatus();
+      statusMarkup = null;
+    } else if (original === 'deepl')
+      statusMarkup = I18N[lang].translationDeeplHtml || I18N[lang].translationEnabledHtml;
     else if (original === 'chatgpt')
-      translationStatus.innerHTML = I18N[lang].translationChatgptHtml || I18N[lang].translationEnabledHtml;
+      statusMarkup = I18N[lang].translationChatgptHtml || I18N[lang].translationEnabledHtml;
     else if (original === 'gemini')
-      translationStatus.innerHTML = I18N[lang].translationGeminiHtml || I18N[lang].translationEnabledHtml;
-    else translationStatus.innerHTML = I18N[lang].translationEnabledHtml;
+      statusMarkup = I18N[lang].translationGeminiHtml || I18N[lang].translationEnabledHtml;
+    if (statusMarkup) setStatusMarkup(translationStatus, statusMarkup);
   }
   // Local 서브-셀렉트 가시성 토글 (local일 때만 표시)
   const localGrp = document.getElementById('localModelGroup');
@@ -1996,9 +2048,12 @@ async function checkGpuCompatibility() {
   const lang = I18N[currentUiLang];
   const deviceStatus = document.getElementById('deviceStatus');
   if (!info.cudaCompatible && deviceStatus) {
-    deviceStatus.innerHTML = lang.gpuIncompatibleHtml
-      ? lang.gpuIncompatibleHtml(info.name, info.computeCap)
-      : `<strong style="color:#e74c3c;">⚠ ${info.name} (Compute ${info.computeCap})</strong><br>CUDA 12 requires Compute 5.0+. GPU mode unavailable. CPU mode will be used automatically.`;
+    setStatusMarkup(
+      deviceStatus,
+      lang.gpuIncompatibleHtml
+        ? lang.gpuIncompatibleHtml(info.name, info.computeCap)
+        : `<strong style="color:#e74c3c;">⚠ ${info.name} (Compute ${info.computeCap})</strong><br>CUDA 12 requires Compute 5.0+. GPU mode unavailable. CPU mode will be used automatically.`
+    );
   }
 }
 
@@ -2235,14 +2290,17 @@ function applyI18n(lang) {
   if (d.emptyQueueTitle) setText('emptyQueueTitle', d.emptyQueueTitle);
   if (d.emptyQueueHint) {
     const hint = document.getElementById('emptyQueueHint');
-    if (hint) hint.innerHTML = d.emptyQueueHint.replace(/\n/g, '<br>');
+    if (hint) setSafeHtml(hint, d.emptyQueueHint.replace(/\n/g, '<br>'));
   }
 
   // 설정 모달 i18n
   setText('settingsModalTitle', d.settingsModalTitle);
   const soundSection = document.getElementById('soundSectionTitle');
   if (soundSection)
-    soundSection.innerHTML = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width: 16px; height: 16px;"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"/></svg> ${d.soundSectionTitle}`;
+    setSafeHtml(
+      soundSection,
+      `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width: 16px; height: 16px;"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"/></svg> ${d.soundSectionTitle}`
+    );
   setText('soundEnabledLabel', d.soundEnabled);
   setText('soundVolumeLabelModal', d.soundVolume);
   setText('soundTestLabelModal', d.soundTest);
@@ -2252,7 +2310,10 @@ function applyI18n(lang) {
   if (d.historyToggleHint) setText('historyHint', d.historyToggleHint);
   const apiSection = document.getElementById('apiSectionTitle');
   if (apiSection)
-    apiSection.innerHTML = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width: 16px; height: 16px;"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg> ${d.apiSectionTitle}`;
+    setSafeHtml(
+      apiSection,
+      `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width: 16px; height: 16px;"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg> ${d.apiSectionTitle}`
+    );
   setText('labelDeeplKey', d.labelDeeplKey);
   setText('labelOpenaiKey', d.labelOpenaiKey);
   setText('labelGeminiKey', d.labelGeminiKey);
@@ -2262,15 +2323,15 @@ function applyI18n(lang) {
   const deeplInput = document.getElementById('deeplApiKey');
   if (deeplInput) deeplInput.placeholder = d.deeplPlaceholder;
   const deeplHelp = document.getElementById('deeplHelp');
-  if (deeplHelp) deeplHelp.innerHTML = d.deeplHelpHtml;
+  if (deeplHelp) setSafeHtml(deeplHelp, d.deeplHelpHtml);
   const openaiInput = document.getElementById('openaiApiKey');
   if (openaiInput) openaiInput.placeholder = d.openaiPlaceholder;
   const openaiHelp = document.getElementById('openaiHelp');
-  if (openaiHelp) openaiHelp.innerHTML = d.openaiHelpHtml;
+  if (openaiHelp) setSafeHtml(openaiHelp, d.openaiHelpHtml);
   const geminiInput = document.getElementById('geminiApiKey');
   if (geminiInput) geminiInput.placeholder = d.geminiPlaceholder;
   const geminiHelp = document.getElementById('geminiHelp');
-  if (geminiHelp) geminiHelp.innerHTML = d.geminiHelpHtml;
+  if (geminiHelp) setSafeHtml(geminiHelp, d.geminiHelpHtml);
   // 토글 버튼 툴팁
   document.querySelectorAll('.toggle-password').forEach((btn) => {
     btn.title = d.togglePasswordShow || 'Show password';
@@ -2312,7 +2373,7 @@ function updateModelSelect() {
   // 현재 선택된 모델 저장 (언어 변경 시 유지)
   const previousValue = modelSelect.value;
 
-  modelSelect.innerHTML = '';
+  modelSelect.replaceChildren();
 
   // 성능 좋은 순서 (위가 더 좋음). large-v2-sync는 별도 엔진(Faster-Whisper-XXL). 장치 선택을 따른다.
   const ids = ['large-v3-turbo', 'large-v2-sync', 'large-v2-sync-lite', 'large-v3', 'medium', 'small', 'base', 'tiny'];
@@ -2360,7 +2421,7 @@ function updateModelSelect() {
   if (modelStatus) {
     const base = I18N[currentUiLang].modelStatusText(availableCount);
     const manageLabel = I18N[currentUiLang].modelManageHint || 'Pre-download in Model Manager';
-    modelStatus.innerHTML = `${base} <a href="#" id="openModelsLink" class="inline-link">${manageLabel} →</a>`;
+    setSafeHtml(modelStatus, `${base} <a href="#" id="openModelsLink" class="inline-link">${manageLabel} →</a>`);
     const openLink = document.getElementById('openModelsLink');
     if (openLink)
       openLink.addEventListener('click', (e) => {
@@ -2426,13 +2487,14 @@ function updateModelRequirements(modelId) {
 
   const reqText = texts[currentUiLang] || texts.en;
   // 모델 상세 설명(select 드롭다운 잘림 피해 이리로 옮긴 것). select 아래에 풀로 표시.
-  const descMap = (typeof MODEL_DESC_I18N !== 'undefined' && (MODEL_DESC_I18N[currentUiLang] || MODEL_DESC_I18N.en)) || {};
+  const descMap =
+    (typeof MODEL_DESC_I18N !== 'undefined' && (MODEL_DESC_I18N[currentUiLang] || MODEL_DESC_I18N.en)) || {};
   const descText = descMap[modelId] || '';
   const descHtml = descText ? `<span class="model-req-desc">${descText}</span><br>` : '';
 
   const isInstalled = !!(typeof availableModels !== 'undefined' && availableModels && availableModels[modelId]);
   if (isInstalled) {
-    requirementsEl.innerHTML = `${descHtml}${reqText}`;
+    setSafeHtml(requirementsEl, `${descHtml}${reqText}`);
     requirementsEl.classList.remove('need-download');
   } else {
     const warn = {
@@ -2442,7 +2504,10 @@ function updateModelRequirements(modelId) {
       zh: '⚠ 未安装 — 启动时自动下载，或在模型管理中预先下载。',
       pl: '⚠ Nie zainstalowano — pobierze się automatycznie lub możesz pobrać wcześniej w Menedżerze modeli.',
     };
-    requirementsEl.innerHTML = `${descHtml}${reqText}<br><span class="need-download-msg">${warn[currentUiLang] || warn.en}</span>`;
+    setSafeHtml(
+      requirementsEl,
+      `${descHtml}${reqText}<br><span class="need-download-msg">${warn[currentUiLang] || warn.en}</span>`
+    );
     requirementsEl.classList.add('need-download');
   }
 }
@@ -2484,13 +2549,16 @@ function updateQueueDisplayImmediate() {
     if (pauseBtn) pauseBtn.style.display = 'none';
     stopBtn.style.display = 'none';
     // 빈 상태 메시지 표시
-    queueList.innerHTML = `<div class="queue-empty">
+    setSafeHtml(
+      queueList,
+      `<div class="queue-empty">
       <div class="queue-empty-icon queue-empty-pixel">
         <img src="assets/px-empty-queue.png?v=3" alt="" aria-hidden="true"/>
       </div>
       <p class="queue-empty-title">${d.emptyQueueTitle || d.queueEmpty || 'Queue is empty'}</p>
       <p class="queue-empty-hint">${(d.emptyQueueHint || 'Drop a video or SRT file onto the dropzone').replace(/\n/g, '<br>')}</p>
-    </div>`;
+    </div>`
+    );
     return;
   }
 
@@ -2522,78 +2590,81 @@ function updateQueueDisplayImmediate() {
       .replace(/>/g, '&gt;');
   }
 
-  queueList.innerHTML = fileQueue
-    .map((file, index) => {
-      const fullFileName = file.path.split('\\').pop() || file.path.split('/').pop();
-      const ext = fullFileName.lastIndexOf('.') > 0 ? fullFileName.substring(fullFileName.lastIndexOf('.')) : '';
-      const isSrt = ext.toLowerCase() === '.srt';
+  setSafeHtml(
+    queueList,
+    fileQueue
+      .map((file, index) => {
+        const fullFileName = file.path.split('\\').pop() || file.path.split('/').pop();
+        const ext = fullFileName.lastIndexOf('.') > 0 ? fullFileName.substring(fullFileName.lastIndexOf('.')) : '';
+        const isSrt = ext.toLowerCase() === '.srt';
 
-      // 파일명 표시: 이름 부분만 줄이고 확장자는 뱃지로 표시
-      const nameWithoutExt = fullFileName.substring(0, fullFileName.length - ext.length);
-      const maxNameLength = 25;
-      let displayName = nameWithoutExt;
-      if (nameWithoutExt.length > maxNameLength) {
-        displayName = nameWithoutExt.substring(0, maxNameLength) + '...';
-      }
-      // 확장자 뱃지 (SRT는 보라색, 동영상은 초록색)
-      const extBadge = isSrt
-        ? `<span class="ext-badge srt">SRT</span>`
-        : `<span class="ext-badge video">${ext.toUpperCase().substring(1)}</span>`;
+        // 파일명 표시: 이름 부분만 줄이고 확장자는 뱃지로 표시
+        const nameWithoutExt = fullFileName.substring(0, fullFileName.length - ext.length);
+        const maxNameLength = 25;
+        let displayName = nameWithoutExt;
+        if (nameWithoutExt.length > maxNameLength) {
+          displayName = nameWithoutExt.substring(0, maxNameLength) + '...';
+        }
+        // 확장자 뱃지 (SRT는 보라색, 동영상은 초록색)
+        const extBadge = isSrt
+          ? `<span class="ext-badge srt">SRT</span>`
+          : `<span class="ext-badge video">${ext.toUpperCase().substring(1)}</span>`;
 
-      const isValid = isVideoFile(file.path) || isSrtFile(file.path);
+        const isValid = isVideoFile(file.path) || isSrtFile(file.path);
 
-      let statusText = d.qWaiting;
-      let itemClass = 'queue-item';
+        let statusText = d.qWaiting;
+        let itemClass = 'queue-item';
 
-      if (file.status === 'completed') {
-        statusText = d.qCompleted;
-        itemClass = 'queue-item completed';
-      } else if (file.status === 'processing') {
-        statusText = d.qProcessing;
-        itemClass = 'queue-item processing';
-      } else if (file.status === 'translating') {
-        statusText = d.qTranslating;
-        itemClass = 'queue-item processing';
-      } else if (file.status === 'stopped') {
-        statusText = d.qStopped;
-        itemClass = 'queue-item error';
-      } else if (file.status === 'skipped') {
-        statusText = d.qSkipped || 'Skipped';
-        itemClass = 'queue-item skipped';
-      } else if (file.status === 'error') {
-        statusText = d.qError;
-        itemClass = 'queue-item error';
-      } else if (!isValid) {
-        statusText = d.qUnsupported;
-        itemClass = 'queue-item error';
-      }
+        if (file.status === 'completed') {
+          statusText = d.qCompleted;
+          itemClass = 'queue-item completed';
+        } else if (file.status === 'processing') {
+          statusText = d.qProcessing;
+          itemClass = 'queue-item processing';
+        } else if (file.status === 'translating') {
+          statusText = d.qTranslating;
+          itemClass = 'queue-item processing';
+        } else if (file.status === 'stopped') {
+          statusText = d.qStopped;
+          itemClass = 'queue-item error';
+        } else if (file.status === 'skipped') {
+          statusText = d.qSkipped || 'Skipped';
+          itemClass = 'queue-item skipped';
+        } else if (file.status === 'error') {
+          statusText = d.qError;
+          itemClass = 'queue-item error';
+        } else if (!isValid) {
+          statusText = d.qUnsupported;
+          itemClass = 'queue-item error';
+        }
 
-      const maxPathLength = 80;
-      const displayPath = file.path.length > maxPathLength ? file.path.substring(0, maxPathLength) + '...' : file.path;
+        const maxPathLength = 80;
+        const displayPath =
+          file.path.length > maxPathLength ? file.path.substring(0, maxPathLength) + '...' : file.path;
 
-      const btnOpen = d.btnOpen;
-      const btnRemove = d.btnRemove;
-      const processingBadge = `<span style="color: #ffc107; font-size: 12px; font-weight: 600;">${d.qProcessing}</span>`;
+        const btnOpen = d.btnOpen;
+        const btnRemove = d.btnRemove;
+        const processingBadge = `<span style="color: #ffc107; font-size: 12px; font-weight: 600;">${d.qProcessing}</span>`;
 
-      // 처리 중이 아닌 경우에만 드래그 가능
-      const isDraggable = file.status !== 'processing' && file.status !== 'translating';
-      const dragAttr = isDraggable ? `draggable="true" data-index="${index}"` : '';
+        // 처리 중이 아닌 경우에만 드래그 가능
+        const isDraggable = file.status !== 'processing' && file.status !== 'translating';
+        const dragAttr = isDraggable ? `draggable="true" data-index="${index}"` : '';
 
-      // Safe HTML generation: all user data in data-* attrs only, no inline JS
-      let actionButtons = '';
-      if (file.status === 'completed') {
-        actionButtons = `<button class="btn-success btn-sm" data-action="open" data-index="${index}">${escAttr(btnOpen)}</button>`;
-      } else if (file.status === 'processing' || file.status === 'translating') {
-        actionButtons = processingBadge;
-      } else if (file.status === 'error' || file.status === 'stopped') {
-        actionButtons =
-          `<button class="btn-warning btn-sm" style="margin-right:4px;" data-action="retry" data-index="${index}">${escAttr(d.btnRetry || 'Retry')}</button>` +
-          `<button class="btn-danger btn-sm" data-action="remove" data-index="${index}">${escAttr(btnRemove)}</button>`;
-      } else {
-        actionButtons = `<button class="btn-danger btn-sm" data-action="remove" data-index="${index}">${escAttr(btnRemove)}</button>`;
-      }
+        // Safe HTML generation: all user data in data-* attrs only, no inline JS
+        let actionButtons = '';
+        if (file.status === 'completed') {
+          actionButtons = `<button class="btn-success btn-sm" data-action="open" data-index="${index}">${escAttr(btnOpen)}</button>`;
+        } else if (file.status === 'processing' || file.status === 'translating') {
+          actionButtons = processingBadge;
+        } else if (file.status === 'error' || file.status === 'stopped') {
+          actionButtons =
+            `<button class="btn-warning btn-sm" style="margin-right:4px;" data-action="retry" data-index="${index}">${escAttr(d.btnRetry || 'Retry')}</button>` +
+            `<button class="btn-danger btn-sm" data-action="remove" data-index="${index}">${escAttr(btnRemove)}</button>`;
+        } else {
+          actionButtons = `<button class="btn-danger btn-sm" data-action="remove" data-index="${index}">${escAttr(btnRemove)}</button>`;
+        }
 
-      return `
+        return `
       <div class="${itemClass}${isDraggable ? ' draggable' : ''}" ${dragAttr}>
         ${isDraggable ? `<div class="drag-handle" title="${escAttr(d.dragHandleTooltip || 'Drag to reorder')}">&#9776;</div>` : ''}
         <div class="file-info">
@@ -2604,8 +2675,9 @@ function updateQueueDisplayImmediate() {
         <div>${actionButtons}</div>
       </div>
     `;
-    })
-    .join('');
+      })
+      .join('')
+  );
 
   // 드래그 앤 드롭 이벤트 설정
   setupQueueDragAndDrop();
@@ -2931,24 +3003,24 @@ function initTranslationSelect() {
     const method = translationSelect.value;
     if (method === 'none') {
       targetLanguageGroup.style.display = 'none';
-      if (translationStatus) translationStatus.innerHTML = I18N[currentUiLang].translationDisabledHtml;
+      if (translationStatus) setStatusMarkup(translationStatus, I18N[currentUiLang].translationDisabledHtml);
     } else {
       targetLanguageGroup.style.display = '';
       if (translationStatus) {
         // 선택한 번역 방법에 따라 다른 메시지 표시
         if (method === 'mymemory') {
-          translationStatus.innerHTML = I18N[currentUiLang].translationEnabledHtml;
+          setStatusMarkup(translationStatus, I18N[currentUiLang].translationEnabledHtml);
         } else if (method === 'deepl') {
-          translationStatus.innerHTML = I18N[currentUiLang].translationDeeplHtml;
+          setStatusMarkup(translationStatus, I18N[currentUiLang].translationDeeplHtml);
         } else if (method === 'chatgpt') {
-          translationStatus.innerHTML = I18N[currentUiLang].translationChatgptHtml;
+          setStatusMarkup(translationStatus, I18N[currentUiLang].translationChatgptHtml);
         } else if (method === 'gemini') {
-          translationStatus.innerHTML = I18N[currentUiLang].translationGeminiHtml;
+          setStatusMarkup(translationStatus, I18N[currentUiLang].translationGeminiHtml);
         } else if (method === 'local') {
           // Check model install status
           updateLocalModelStatus();
         } else {
-          translationStatus.innerHTML = I18N[currentUiLang].translationEnabledHtml;
+          setStatusMarkup(translationStatus, I18N[currentUiLang].translationEnabledHtml);
         }
       }
     }
@@ -3226,7 +3298,10 @@ function renderLocalModelRequirements(modelId) {
     pl: { fast: 'Szybko', slow: 'Wolno (wysoka jakość)', normal: 'Normalnie' },
   };
   const speed = (speedMap[currentUiLang] || speedMap.en)[speedKey];
-  el.innerHTML = `<span style="font-size:10.5px;color:var(--text-muted)">${label}: VRAM ${r.vram} / RAM ${r.ram} · ${speed}</span>`;
+  setSafeHtml(
+    el,
+    `<span style="font-size:10.5px;color:var(--text-muted)">${label}: VRAM ${r.vram} / RAM ${r.ram} · ${speed}</span>`
+  );
 }
 
 async function updateLocalModelStatus() {
@@ -3250,16 +3325,23 @@ async function updateLocalModelStatus() {
   const sizeText = info.sizeMB ? ` (${(info.sizeMB / 1024).toFixed(1)} GB)` : '';
 
   if (info.installed) {
-    statusEl.innerHTML = `<span style="color:var(--accent)">${d.localModelInstalledHtml || '&#10003; Hy-MT2 model installed'}${sizeText}</span>`;
+    setSafeHtml(
+      statusEl,
+      `<span style="color:var(--accent)">${d.localModelInstalledHtml || '&#10003; Hy-MT2 model installed'}${sizeText}</span>`
+    );
   } else if (_localDownloading) {
-    statusEl.innerHTML = `
-      <div style="font-size:10px;color:var(--text-muted);margin-bottom:4px">${d.localModelDownloadingHtml || 'Downloading Hy-MT2 Q4...'} <span id="localDlPercent">0%</span></div>
+    setSafeHtml(
+      statusEl,
+      `<div style="font-size:10px;color:var(--text-muted);margin-bottom:4px">${d.localModelDownloadingHtml || 'Downloading Hy-MT2 Q4...'} <span id="localDlPercent">0%</span></div>
       <div style="height:4px;background:var(--bg-tertiary);border-radius:2px;overflow:hidden;width:100%">
         <div id="localDlBar" style="height:100%;width:0%;background:var(--accent);transition:width 0.3s;"></div>
-      </div>
-    `;
+      </div>`
+    );
   } else {
-    statusEl.innerHTML = `<span style="color:var(--text-muted);font-size:11px">${d.localModelMissingHtml || '⚠ Hy-MT2 model not installed — auto-downloads on start'}${sizeText}</span>`;
+    setSafeHtml(
+      statusEl,
+      `<span style="color:var(--text-muted);font-size:11px">${d.localModelMissingHtml || '⚠ Hy-MT2 model not installed — auto-downloads on start'}${sizeText}</span>`
+    );
   }
 }
 
@@ -3275,12 +3357,13 @@ if (window.electronAPI?.onLocalModelProgress) {
     let bar = document.getElementById('localDlBar');
     let pct = document.getElementById('localDlPercent');
     if (!bar || !pct) {
-      statusEl.innerHTML = `
-        <div style="font-size:10px;color:var(--text-muted);margin-bottom:4px">${I18N[currentUiLang].localModelDownloadingHtml || 'Downloading Hy-MT2 Q4...'} <span id="localDlPercent">${percent}%</span></div>
+      setSafeHtml(
+        statusEl,
+        `<div style="font-size:10px;color:var(--text-muted);margin-bottom:4px">${I18N[currentUiLang].localModelDownloadingHtml || 'Downloading Hy-MT2 Q4...'} <span id="localDlPercent">${percent}%</span></div>
         <div style="height:4px;background:var(--bg-tertiary);border-radius:2px;overflow:hidden;width:100%">
           <div id="localDlBar" style="height:100%;width:${percent}%;background:var(--accent);transition:width 0.3s;"></div>
-        </div>
-      `;
+        </div>`
+      );
     } else {
       bar.style.width = percent + '%';
       pct.textContent = percent + '%';
@@ -3335,7 +3418,7 @@ function buildCustomSelect(selectEl) {
   selectEl.classList.add('custom-hidden');
 
   function refreshOptions() {
-    dropdown.innerHTML = '';
+    dropdown.replaceChildren();
     const opts = Array.from(selectEl.options);
     opts.forEach((opt) => {
       if (opt.hidden) return;
@@ -4181,7 +4264,7 @@ async function testApiKeys() {
         status.style.border = '1px solid #ffeeba';
         status.style.color = '#856404';
       }
-      status.innerHTML = messages.join('<br>');
+      setSafeHtml(status, messages.join('<br>'));
     } else if (status) {
       const pleaseEnterMsg = {
         ko: '키 먼저 입력!',
@@ -4549,20 +4632,24 @@ function renderHistory(filter) {
 
   const d = I18N[currentUiLang] || I18N.ko;
   if (!filtered.length) {
-    listEl.innerHTML = `
-      <div class="history-empty">
+    setSafeHtml(
+      listEl,
+      `<div class="history-empty">
         <div class="history-empty-pixel">
           <img src="assets/px-empty-history.png?v=3" alt="" aria-hidden="true"/>
         </div>
         <p class="history-empty-title">${q ? d.histNoResult || 'No results' : d.histEmptyTitle || 'No history yet'}</p>
         <p class="history-empty-hint">${q ? d.histNoResultHint || 'Try another search' : d.histEmptyHint || 'Process a file to see it here'}</p>
-      </div>`;
+      </div>`
+    );
     return;
   }
 
-  listEl.innerHTML = filtered
-    .map(
-      (it) => `
+  setSafeHtml(
+    listEl,
+    filtered
+      .map(
+        (it) => `
     <div class="history-item">
       <span class="history-item-status ${it.status === 'success' ? 'success' : 'failed'}" title="${it.status}"></span>
       <span class="history-item-name" title="${_esc(it.path || it.name)}">${_esc(it.name || '')}</span>
@@ -4574,8 +4661,9 @@ function renderHistory(filter) {
       </span>
     </div>
   `
-    )
-    .join('');
+      )
+      .join('')
+  );
 
   // Bind action buttons:
   //  - data-hist-open  → 파일 자체 실행 (영상=플레이어, .srt=에디터)
@@ -4662,7 +4750,7 @@ function _updateModelCardProgress(cardId, percent) {
   if (!bar) {
     bar = document.createElement('div');
     bar.className = 'model-card-progress';
-    bar.innerHTML = '<div class="model-card-progress-fill"></div><span class="model-card-progress-text"></span>';
+    setSafeHtml(bar, '<div class="model-card-progress-fill"></div><span class="model-card-progress-text"></span>');
     const actions = card.querySelector('.model-card-actions');
     if (actions) actions.parentNode.insertBefore(bar, actions);
   }
@@ -4871,7 +4959,7 @@ async function renderModels() {
         <div class="model-card-meta">
           <div class="model-card-meta-item">
             <span class="model-card-meta-label">${D.modelMetaSize || 'Size'}</span>
-            <span class="model-card-meta-value">${m.sizeKey === 'shared' ? (D.modelSizeShared || 'Shared') : m.size}</span>
+            <span class="model-card-meta-value">${m.sizeKey === 'shared' ? D.modelSizeShared || 'Shared' : m.size}</span>
           </div>
           <div class="model-card-meta-item">
             <span class="model-card-meta-label">${D.modelMetaVram || 'VRAM'}</span>
@@ -4896,8 +4984,9 @@ async function renderModels() {
   const sectionTrHint = D.modelSectionTranslationHint || 'Text → another language';
   const sectionAsHint = D.modelSectionAsrHint || 'Audio → subtitle text';
 
-  grid.innerHTML = `
-    <section class="model-section">
+  setSafeHtml(
+    grid,
+    `<section class="model-section">
       <header class="model-section-header">
         <div class="model-section-title-wrap">
           <span class="model-section-dot lavender"></span>
@@ -4918,8 +5007,8 @@ async function renderModels() {
         <span class="model-section-count">${asrModels.filter((m) => installedSet.has(m.id)).length} / ${asrModels.length}</span>
       </header>
       <div class="model-section-grid">${asrModels.map(cardHtml).join('')}</div>
-    </section>
-  `;
+    </section>`
+  );
 
   // Bind download actions
   grid.querySelectorAll('[data-model-action="download"]').forEach((btn) => {

--- a/renderer.js
+++ b/renderer.js
@@ -2608,7 +2608,7 @@ function updateQueueDisplayImmediate() {
         // 확장자 뱃지 (SRT는 보라색, 동영상은 초록색)
         const extBadge = isSrt
           ? `<span class="ext-badge srt">SRT</span>`
-          : `<span class="ext-badge video">${ext.toUpperCase().substring(1)}</span>`;
+          : `<span class="ext-badge video">${escAttr(ext.toUpperCase().substring(1))}</span>`;
 
         const isValid = isVideoFile(file.path) || isSrtFile(file.path);
 

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const EnhancedSubtitleTranslator = require('../translator-enhanced');
+const localTranslator = require('../local-translator');
 const { hasWhisperRuntimeLibraries } = require('./postinstall');
 const { applySrtCleanup, isSdhOnlyText, srtFromWhisperJson } = require('../srt-cleanup');
 
@@ -19,10 +20,22 @@ function runSrtCleanup() {
 
   // SDH (A안): drop tag-only cues, keep mixed lines, renumber
   const sdh = [
-    '1', '00:00:01,000 --> 00:00:03,000', '[music playing]', '',
-    '2', '00:00:04,000 --> 00:00:06,000', "(sighs) I can't believe it", '',
-    '3', '00:00:07,000 --> 00:00:08,000', '(applause)', '',
-    '4', '00:00:09,000 --> 00:00:10,000', 'Real dialogue', '',
+    '1',
+    '00:00:01,000 --> 00:00:03,000',
+    '[music playing]',
+    '',
+    '2',
+    '00:00:04,000 --> 00:00:06,000',
+    "(sighs) I can't believe it",
+    '',
+    '3',
+    '00:00:07,000 --> 00:00:08,000',
+    '(applause)',
+    '',
+    '4',
+    '00:00:09,000 --> 00:00:10,000',
+    'Real dialogue',
+    '',
   ].join('\n');
   const sdhOut = applySrtCleanup(sdh, { removeSDH: true });
   assert.ok(!sdhOut.includes('[music playing]') && !/\(applause\)/.test(sdhOut));
@@ -86,7 +99,100 @@ function runWhisperRuntimeProbe() {
   }
 }
 
-function run() {
+async function runLocalTranslationGuards() {
+  assert.strictEqual(localTranslator.looksUntranslated('Hola mundo!', 'Hola mundo.', 'en'), true);
+  assert.strictEqual(localTranslator.looksUntranslated('Hello world', 'Hola mundo', 'en'), false);
+  assert.strictEqual(localTranslator.looksUntranslated('こんにちは', 'こんにちは', 'en'), true);
+  assert.strictEqual(localTranslator.isEffectivelySameText('Original: Hola mundo', 'Hola mundo', 1), true);
+
+  const waitForAbort = (signal) =>
+    new Promise((_, reject) => signal.addEventListener('abort', () => reject(signal.reason), { once: true }));
+  await assert.rejects(() => localTranslator.withTimeout(waitForAbort, 20), /LOCAL_TIMEOUT/);
+
+  const parent = new AbortController();
+  const aborted = localTranslator.withTimeout(waitForAbort, 1000, parent.signal);
+  parent.abort(new Error('ABORTED: test'));
+  await assert.rejects(() => aborted, /ABORTED/);
+
+  const sequential = new EnhancedSubtitleTranslator();
+  let active = 0;
+  let maxActive = 0;
+  sequential.translateAuto = async (text) => {
+    active++;
+    maxActive = Math.max(maxActive, active);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    active--;
+    return `translated ${text}`;
+  };
+  await sequential.translateBatch(['one', 'two', 'three'], 'local', 'en');
+  assert.strictEqual(maxActive, 1, 'local translations must not queue parallel work behind the model mutex');
+
+  const timeout = new EnhancedSubtitleTranslator();
+  timeout.translateAuto = async () => {
+    throw new Error('LOCAL_TIMEOUT: test');
+  };
+  await assert.rejects(() => timeout.translateBatch(['one', 'two'], 'local', 'en'), /LOCAL_TIMEOUT/);
+
+  const passthrough = new EnhancedSubtitleTranslator();
+  let calls = 0;
+  passthrough.translateAuto = async () => {
+    calls++;
+    throw new Error('LOCAL_UNTRANSLATED: test');
+  };
+  await assert.rejects(
+    () => passthrough.translateBatch(['one', 'two', 'three', 'four', 'five', 'six'], 'local', 'en'),
+    /TRANSLATION_PASSTHROUGH/
+  );
+  assert.strictEqual(calls, 5, 'repeated local echoes should fail before processing the whole file');
+
+  const makeSrt = (texts) =>
+    texts
+      .map(
+        (text, i) =>
+          `${i + 1}\n00:00:${String(i).padStart(2, '0')},000 --> 00:00:${String(i + 1).padStart(2, '0')},000\n${text}`
+      )
+      .join('\n\n');
+
+  const exactEcho = new EnhancedSubtitleTranslator();
+  exactEcho.translateBatch = async (texts) => texts;
+  await assert.rejects(
+    () => exactEcho.translateSRTContent(makeSrt(Array(4).fill('Hola mundo')), 'local', 'en'),
+    /TRANSLATION_PASSTHROUGH/
+  );
+
+  const normalizedGuard = new EnhancedSubtitleTranslator();
+  normalizedGuard.translateBatch = async (texts) => texts.map((text) => `${text}!!!`);
+  await assert.rejects(
+    () => normalizedGuard.translateSRTContent(makeSrt(Array(4).fill('Hola mundo')), 'local', 'en'),
+    /TRANSLATION_PASSTHROUGH/
+  );
+
+  const mostlyUntranslated = new EnhancedSubtitleTranslator();
+  mostlyUntranslated.translateBatch = async (texts) =>
+    texts.map((text, index) => (index === 4 ? 'Translated line' : text));
+  await assert.rejects(
+    () => mostlyUntranslated.translateSRTContent(makeSrt(Array(5).fill('Hola mundo')), 'local', 'en'),
+    /TRANSLATION_PASSTHROUGH/
+  );
+
+  const labeledEcho = new EnhancedSubtitleTranslator();
+  labeledEcho.translateBatch = async (texts) => texts.map((text) => `Original: ${text}`);
+  await assert.rejects(
+    () => labeledEcho.translateSRTContent(makeSrt(['Hola mundo']), 'local', 'en'),
+    /TRANSLATION_PASSTHROUGH/
+  );
+
+  const validWithName = new EnhancedSubtitleTranslator();
+  validWithName.translateBatch = async () => ['Christopher', 'Hello', 'Good morning', 'Thank you', 'Goodbye'];
+  const validOutput = await validWithName.translateSRTContent(
+    makeSrt(['Christopher', 'Hola', 'Buenos días', 'Gracias', 'Adiós']),
+    'local',
+    'en'
+  );
+  assert.ok(validOutput.includes('Christopher') && validOutput.includes('Goodbye'));
+}
+
+async function run() {
   const translator = new EnhancedSubtitleTranslator();
 
   assert.strictEqual(translator.mapToDeepLLang('ko'), 'KO');
@@ -107,21 +213,17 @@ function run() {
 
   const parsed = translator.parseContextAwareJson('```json\n{"translations":["안녕"],"summary":"greeting"}\n```');
   assert.deepStrictEqual(parsed.translations, ['안녕']);
-  assert.throws(
-    () => translator.parseContextAwareJson('not json'),
-    /Invalid context-aware translation response/
-  );
+  assert.throws(() => translator.parseContextAwareJson('not json'), /Invalid context-aware translation response/);
 
   runSrtCleanup();
   runSrtFromWhisperJson();
   runWhisperRuntimeProbe();
+  await runLocalTranslationGuards();
 
   console.log('Smoke tests passed.');
 }
 
-try {
-  run();
-} catch (error) {
+run().catch((error) => {
   console.error(error);
   process.exit(1);
-}
+});

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -99,6 +99,67 @@ function runWhisperRuntimeProbe() {
   }
 }
 
+async function runModelDownloadAbort() {
+  const https = require('https');
+  const { EventEmitter } = require('events');
+  const electronPath = require.resolve('electron');
+  const originalElectron = require.cache[electronPath].exports;
+  const originalGet = https.get;
+  const modelDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wst-model-abort-'));
+  const controller = new AbortController();
+  let requestCount = 0;
+  let destroyed = false;
+
+  try {
+    require.cache[electronPath].exports = { app: { getPath: () => modelDir } };
+    https.get = (_url, callback) => {
+      const request = new EventEmitter();
+      request.destroy = () => {
+        destroyed = true;
+        request.emit('error', new Error('socket closed'));
+      };
+      requestCount++;
+      if (requestCount === 1) {
+        queueMicrotask(() => callback({ statusCode: 302, headers: { location: 'https://example.test/model' }, resume() {} }));
+      } else {
+        queueMicrotask(() => controller.abort(new Error('ABORTED: test download')));
+      }
+      return request;
+    };
+
+    await assert.rejects(() => localTranslator.downloadModel(null, controller.signal), /ABORTED: test download/);
+    assert.strictEqual(requestCount, 2, 'download should follow one redirect before aborting');
+    assert.strictEqual(destroyed, true, 'abort should destroy the active request before a response arrives');
+
+    requestCount = 0;
+    destroyed = false;
+    https.get = () => {
+      const request = new EventEmitter();
+      request.destroy = () => {
+        destroyed = true;
+        request.emit('error', new Error('socket closed'));
+      };
+      requestCount++;
+      return request;
+    };
+
+    const owner = new AbortController();
+    const ownerDownload = localTranslator.downloadModel(null, owner.signal);
+    const waiter = new AbortController();
+    waiter.abort(new Error('ABORTED: second waiter'));
+    await assert.rejects(() => localTranslator.downloadModel(null, waiter.signal), /ABORTED: second waiter/);
+    assert.strictEqual(destroyed, false, 'a waiting caller must not cancel the shared transfer');
+    owner.abort(new Error('ABORTED: download owner'));
+    await assert.rejects(() => ownerDownload, /ABORTED: download owner/);
+    assert.strictEqual(requestCount, 1, 'shared callers must reuse one request');
+    assert.strictEqual(destroyed, true, 'the transfer owner must still be able to cancel the request');
+  } finally {
+    https.get = originalGet;
+    require.cache[electronPath].exports = originalElectron;
+    fs.rmSync(modelDir, { recursive: true, force: true });
+  }
+}
+
 async function runLocalTranslationGuards() {
   assert.strictEqual(localTranslator.looksUntranslated('Hola mundo!', 'Hola mundo.', 'en'), true);
   assert.strictEqual(localTranslator.looksUntranslated('Hello world', 'Hola mundo', 'en'), false);
@@ -190,6 +251,18 @@ async function runLocalTranslationGuards() {
     'en'
   );
   assert.ok(validOutput.includes('Christopher') && validOutput.includes('Goodbye'));
+
+  const onlineProperName = new EnhancedSubtitleTranslator();
+  onlineProperName.translateBatch = async (texts) => texts;
+  const onlineProperNameOutput = await onlineProperName.translateSRTContent(makeSrt(['Christopher']), 'chatgpt', 'en');
+  assert.ok(onlineProperNameOutput.includes('Christopher'));
+
+  const onlinePassthrough = new EnhancedSubtitleTranslator();
+  onlinePassthrough.translateBatch = async (texts) => texts;
+  await assert.rejects(
+    () => onlinePassthrough.translateSRTContent(makeSrt(Array(5).fill('Hola mundo')), 'chatgpt', 'en'),
+    /TRANSLATION_PASSTHROUGH/
+  );
 }
 
 async function run() {
@@ -218,6 +291,7 @@ async function run() {
   runSrtCleanup();
   runSrtFromWhisperJson();
   runWhisperRuntimeProbe();
+  await runModelDownloadAbort();
   await runLocalTranslationGuards();
 
   console.log('Smoke tests passed.');

--- a/translator-enhanced.js
+++ b/translator-enhanced.js
@@ -228,6 +228,7 @@ class EnhancedSubtitleTranslator {
 
   abort() {
     this._aborted = true;
+    localTranslator.abortTranslation();
     console.log('[Translator] Abort requested');
   }
 
@@ -1289,15 +1290,19 @@ ${lines}`;
   async translateBatch(texts, method = null, targetLang = null, _sourceLang = null, progressCallback = null) {
     const preferredMethod = method || this.apiKeys.preferredService;
 
-    if (!this.apiKeys.batchTranslation || texts.length <= 1) {
-      // 배치 모드가 비활성화되어 있거나 텍스트가 1개 이하면 개별 번역
+    if (preferredMethod === 'local' || !this.apiKeys.batchTranslation || texts.length <= 1) {
+      // 로컬 엔진은 내부 mutex로 직렬화되므로 여기서 병렬 큐를 만들지 않는다.
       const results = [];
+      let localProcessed = 0;
+      let localUntranslated = 0;
       for (let i = 0; i < texts.length; i++) {
+        if (this._aborted) throw new Error('ABORTED: Translation stopped by user');
         try {
           console.log(`[Batch Translation] ${i + 1}/${texts.length}: ${texts[i].substring(0, 40)}...`);
 
           const result = await this.translateAuto(texts[i], method, targetLang);
           results.push(result);
+          if (preferredMethod === 'local') localProcessed++;
 
           console.log(`[Batch Success] ${i + 1}/${texts.length}: ${result.substring(0, 40)}...`);
 
@@ -1320,7 +1325,19 @@ ${lines}`;
           // 로컬(오프라인)을 고른 경우 온라인 API(mymemory/chatgpt)로 폴백하지 않는다.
           // 사용자 의도(오프라인)와 프라이버시를 존중하고, 잘못된 API 키/할당량 에러도 안 뜨게 한다.
           // 원문 유지 → translateSRTContent의 passthrough 안전망이 명확한 에러로 처리한다.
-          if (method === 'local') {
+          if (preferredMethod === 'local') {
+            const message = String(error?.message || error);
+            // 모델 로드/추론 실패와 사용자 중지는 모든 세그먼트에서 반복하지 말고 즉시 알린다.
+            if (!message.includes('LOCAL_UNTRANSLATED')) throw error;
+
+            localProcessed++;
+            localUntranslated++;
+            const failureSample = Math.min(5, texts.length);
+            if (localProcessed >= failureSample && localUntranslated / localProcessed >= 0.8) {
+              throw new Error(
+                `TRANSLATION_PASSTHROUGH: ${localUntranslated}/${localProcessed} local segments were untranslated.`
+              );
+            }
             console.warn(`[Local] segment failed, keeping original (no online fallback): ${i + 1}/${texts.length}`);
           } else {
             for (let retry = 1; retry <= 2; retry++) {
@@ -1626,15 +1643,15 @@ ${lines}`;
     // 안전망: 로컬 모델 크래시/echo 등으로 모든(또는 대부분) 세그먼트가 원문 그대로면
     // translateBatch가 원문을 유지하므로 '번역된 척' 하는 미번역 파일이 만들어진다.
     // 이런 무성(silent) 실패를 성공으로 보고하지 않도록, 미번역 비율이 과도하면 에러를 던진다.
-    // (부분 실패는 통과 — 0.9 임계값은 사실상 전체 실패만 잡는다. 일·한·중처럼 스크립트가
-    //  완전히 다른 번역은 정상이면 거의 0%만 동일하므로 오탐 위험이 낮다.)
+    // 1~4개짜리 짧은 SRT의 전체 echo와 5개 이상에서 80% 이상 echo를 막는다.
+    // 정상 번역은 원문과 정규화 결과가 달라 이 비율에 도달하지 않는다.
     let unchanged = 0;
     for (let k = 0; k < translatedTexts.length; k++) {
       const src = (textsToTranslate[k] || '').trim();
       const out = (translatedTexts[k] || '').trim();
-      if (src && out === src) unchanged++;
+      if (src && localTranslator.isEffectivelySameText(out, src, 1)) unchanged++;
     }
-    if (translatedTexts.length >= 5 && unchanged / translatedTexts.length >= 0.9) {
+    if (translatedTexts.length > 0 && unchanged / translatedTexts.length >= 0.8) {
       throw new Error(
         `TRANSLATION_PASSTHROUGH: ${unchanged}/${translatedTexts.length} segments were left untranslated ` +
           `(translation engine likely failed or crashed). The subtitles were NOT translated.`

--- a/translator-enhanced.js
+++ b/translator-enhanced.js
@@ -1651,7 +1651,12 @@ ${lines}`;
       const out = (translatedTexts[k] || '').trim();
       if (src && localTranslator.isEffectivelySameText(out, src, 1)) unchanged++;
     }
-    if (translatedTexts.length > 0 && unchanged / translatedTexts.length >= 0.8) {
+    const unchangedRatio = translatedTexts.length > 0 ? unchanged / translatedTexts.length : 0;
+    const passthroughDetected =
+      method === 'local'
+        ? translatedTexts.length > 0 && unchangedRatio >= 0.8
+        : translatedTexts.length >= 5 && unchangedRatio >= 0.9;
+    if (passthroughDetected) {
       throw new Error(
         `TRANSLATION_PASSTHROUGH: ${unchanged}/${translatedTexts.length} segments were left untranslated ` +
           `(translation engine likely failed or crashed). The subtitles were NOT translated.`


### PR DESCRIPTION
## What changed

- Serialize local model load, translation, and unload without the nested lock that could freeze Auto to CPU or model switches.
- Abort active local inference when the user stops a job, with a three-minute operation timeout.
- Detect punctuation-only and labeled source echoes, and stop early when most local segments remain untranslated.
- Build renderer status markup without raw localized HTML insertion.
- Bump the app version and add the v2.4.3 changelog entry.

The release also includes the Turkish target and macOS whisper runtime fix already merged after v2.4.2.

## Tested

- `npm run check`
- `npm run test:e2e`
- Real Hy-MT2 1.8B: Auto to CPU to Auto in one process
- 15 source languages translated to English
- 60-cue mixed Japanese and Korean SRT
- Electron SRT translation flow through output file creation
- Active abort followed by a successful retry
- `git diff --check`
